### PR TITLE
Add missing tests for library functions

### DIFF
--- a/Tests/TestAddComment.Codeunit.al
+++ b/Tests/TestAddComment.Codeunit.al
@@ -117,4 +117,21 @@ codeunit 50131 "Test Add Comment"
         AddComment(Comment, 'OK5');
         Assert.AreEqual(ExpectedComment, Comment, 'Adding a new unique comment should change the string.')
     end;
+
+    [Test]
+    procedure TestAddCommentWithDifferentSeparator()
+    var
+        Comment: Text;
+        ExpectedComment: Text;
+    begin
+        // [SCENARIO #007] Adding a new comment with a different separator
+        // [GIVEN] An original list of comments
+        // [WHEN] Adding a new comment with a different separator
+        // [THEN] The resulting string is the original string with the new comment added
+
+        Comment := 'OK1|OK2|OK3|OK4';
+        ExpectedComment := Comment + '|OK5';
+        StandardLibrary.AddCommentSeparator(Comment, 'OK5', '|');
+        Assert.AreEqual(ExpectedComment, Comment, 'Adding a new unique comment with a different separator should change the string.')
+    end;
 }

--- a/Tests/TestDmyFunction.Codeunit.al
+++ b/Tests/TestDmyFunction.Codeunit.al
@@ -85,12 +85,29 @@ codeunit 50137 "Test Dmy Function"
     end;
 
     [Test]
+    procedure TestDmy2DateWithDefaultInvalidDate()
+    var
+        CalculatedDate: Date;
+        DefaultDate: Date;
+
+    begin
+        // [SCENARIO #006] Given an invalid date, will it return the default value.
+        // [GIVEN] An invalid date
+        // [WHEN] Evaluating it
+        // [THEN] We should get the default value
+
+        DefaultDate := Today();
+        CalculatedDate := StandardLibrary.Dmy2DateWithDefault(32, 13, 2023, DefaultDate);
+        Assert.AreEqual(DefaultDate, CalculatedDate, '');
+    end;
+
+    [Test]
     procedure TestTryCreateDateTimeNegative()
     var
         CalculatedDateTime: DateTime;
         ExpectedDateTime: DateTime;
     begin
-        // [SCENARIO #006] The try-function with catch the error
+        // [SCENARIO #007] The try-function with catch the error
         // [GIVEN] a 0D with a time
         // [WHEN] Evaluating it
         // [THEN] We should fail
@@ -106,7 +123,7 @@ codeunit 50137 "Test Dmy Function"
         CalculatedDateTime: DateTime;
         ExpectedDateTime: DateTime;
     begin
-        // [SCENARIO #006] The try-function with catch the error
+        // [SCENARIO #008] The try-function with catch the error
         // [GIVEN] a 0D with a time
         // [WHEN] Evaluating it
         // [THEN] We should fail

--- a/Tests/TestEvaluateXML.Codeunit.al
+++ b/Tests/TestEvaluateXML.Codeunit.al
@@ -345,4 +345,22 @@ codeunit 50132 "Test Evaluate XML"
         Assert.AreEqual(060000T, FoundZone, Iso8601);
         Assert.IsFalse(FoundNegativeTimeZone, 'Positive Time Zone: ' + Iso8601);
     end;
+
+    [Test]
+    procedure TestEvaluateDateTimeFromXMLInvalid()
+    var
+        ExpectedDate: DateTime;
+        FoundDate: DateTime;
+        DateTimeText: Text;
+    begin
+        // [SCENARIO #018] Converting text with an invalid datetime
+        // [GIVEN] An invalid datetime in XML format.
+        // [WHEN] Evaluating it
+        // [THEN] We should not get a date
+
+        DateTimeText := '2019-02-30T12:34:56';
+        ExpectedDate := 0DT;
+        Assert.IsFalse(StandardLibrary.EvaluateDateTimeFromXML(FoundDate, DateTimeText), 'Expected to fail.');
+        Assert.AreEqual(ExpectedDate, FoundDate, 'Expected to evaluate a zero date.');
+    end;
 }

--- a/Tests/TestHexIntConversion.Codeunit.al
+++ b/Tests/TestHexIntConversion.Codeunit.al
@@ -315,4 +315,20 @@ codeunit 50133 "Test Hex Int Conversion"
         Hex := PadStr('', 17, 'F');
         Assert.IsFalse(StandardLibrary.TryHex2Int(Hex, Int), 'Converting a 17 character hex string should fail.');
     end;
+
+    [Test]
+    procedure TestHex2IntWithDefaultInvalidHex()
+    var
+        DefaultIntValue: Integer;
+        Int: Integer;
+    begin
+        // [SCENARIO #018] Attempting to convert an invalid hex string, with a default value.
+        // [GIVEN] invalid hex value and an integer
+        // [WHEN] converting it to integer
+        // [THEN] returns our default value.
+
+        DefaultIntValue := 2023;
+        Int := StandardLibrary.Hex2IntWithDefault('InvalidHex', DefaultIntValue);
+        Assert.AreEqual(DefaultIntValue, Int, '');
+    end;
 }

--- a/Tests/TestMakeDateFilter.Codeunit.al
+++ b/Tests/TestMakeDateFilter.Codeunit.al
@@ -91,4 +91,22 @@ codeunit 50136 "Test Make Date Filter"
 
         Assert.AreEqual(ExpectedString, StandardLibrary.MakeDateFilter(StartingDate, EndingDate), '');
     end;
+
+    [Test]
+    procedure TestDateFilterOnlyStartingDate()
+    var
+        StartingDate: Date;
+        DateFilterTxt: Label '%1..%2', Comment = '%1 = Start Date, %2 = End Date', Locked = true;
+        ExpectedString: Text;
+    begin
+        // [SCENARIO #005] Testing the scenario with only a starting date.
+        // [GIVEN] A starting date
+        // [WHEN] Adding only a starting date
+        // [THEN] The resulting string is the starting date followed by ".."
+
+        StartingDate := Today();
+        ExpectedString := StrSubstNo(DateFilterTxt, StartingDate, '');
+
+        Assert.AreEqual(ExpectedString, StandardLibrary.MakeDateFilter(StartingDate, 0D), '');
+    end;
 }

--- a/Tests/TestRegexFunctions.Codeunit.al
+++ b/Tests/TestRegexFunctions.Codeunit.al
@@ -647,4 +647,18 @@ codeunit 50138 "Test Regex Functions"
         isValidDateTime := StandardLibrary.RegexIsMatch('', Pattern);
         Assert.IsFalse(isValidDateTime, 'Empty string was marked as valid XML datetime string.');
     end;
+
+    [Test]
+    procedure TestRegexIsMatchInvalidPattern()
+    var
+        Pattern: Text;
+    begin
+        // [SCENARIO #002] Testing pattern recognizion with invalid pattern
+        // [GIVEN] Given an invalid pattern
+        // [WHEN] testing if the pattern is recognized
+        // [THEN] it returns false
+
+        Pattern := '^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$';
+        Assert.IsFalse(StandardLibrary.RegexIsMatch('invalid_pattern', Pattern), 'Invalid pattern should not be recognized.');
+    end;
 }

--- a/Tests/TestStringFunctions.Codeunit.al
+++ b/Tests/TestStringFunctions.Codeunit.al
@@ -29,4 +29,15 @@ codeunit 50135 "Test String Functions"
 
         Assert.AreEqual('tatDate', StandardLibrary.KeepChar('StartingDate', 'Date'), '');
     end;
+
+    [Test]
+    procedure TestRemoveCharEmptyString()
+    begin
+        // [SCENARIO #002] Removing characters from an empty string.
+        // [GIVEN] An empty string
+        // [WHEN] removing a set of characters
+        // [THEN] The resulting string is still empty.
+
+        Assert.AreEqual('', StandardLibrary.RemoveChar('', 'Date'), '');
+    end;
 }

--- a/Tests/TestXMLFormat.Codeunit.al
+++ b/Tests/TestXMLFormat.Codeunit.al
@@ -138,6 +138,6 @@ codeunit 50134 "Test XML Format"
         // [WHEN] formating
         // [THEN] correct XML string
 
-        Assert.AreEqual('', StandardLibrary.XMLFormat(NULL), '');
+        Assert.AreEqual('', StandardLibrary.XMLFormat(''), '');
     end;
 }

--- a/Tests/TestXMLFormat.Codeunit.al
+++ b/Tests/TestXMLFormat.Codeunit.al
@@ -129,4 +129,15 @@ codeunit 50134 "Test XML Format"
 
         Assert.AreEqual('2', StandardLibrary.XMLFormat(CustomerBlocked::Invoice), '');
     end;
+
+    [Test]
+    procedure TestXMLFormatNullValue()
+    begin
+        // [SCENARIO #010] Formating null value
+        // [GIVEN] null value
+        // [WHEN] formating
+        // [THEN] correct XML string
+
+        Assert.AreEqual('', StandardLibrary.XMLFormat(NULL), '');
+    end;
 }


### PR DESCRIPTION
Add tests to cover all functions in the library.

* **Tests/TestAddComment.Codeunit.al**
  - Add test for `AddCommentSeparator` function with different separator.

* **Tests/TestDmyFunction.Codeunit.al**
  - Add test for `Dmy2DateWithDefault` function with invalid date.

* **Tests/TestEvaluateXML.Codeunit.al**
  - Add test for `EvaluateDateTimeFromXML` function with invalid datetime.

* **Tests/TestHexIntConversion.Codeunit.al**
  - Add test for `Hex2IntWithDefault` function with invalid hex.

* **Tests/TestMakeDateFilter.Codeunit.al**
  - Add test for `MakeDateFilter` function with only starting date.

* **Tests/TestRegexFunctions.Codeunit.al**
  - Add test for `RegexIsMatch` function with invalid pattern.

* **Tests/TestStringFunctions.Codeunit.al**
  - Add test for `RemoveChar` function with empty string.

* **Tests/TestXMLFormat.Codeunit.al**
  - Add test for `XMLFormat` function with null value.

